### PR TITLE
Add function for manually saving a timer's current milliseconds

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/lifecycleawaretimer/src/main/java/com/franieldancis/lifecycleawaretimer/main/LifecycleAwareTimer.kt
+++ b/lifecycleawaretimer/src/main/java/com/franieldancis/lifecycleawaretimer/main/LifecycleAwareTimer.kt
@@ -3,6 +3,7 @@ package com.franieldancis.lifecycleawaretimer.main
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.CountDownTimer
+import android.util.Log
 import androidx.lifecycle.*
 import java.util.concurrent.TimeUnit
 
@@ -61,7 +62,9 @@ class LifecycleAwareTimer internal constructor(
         checkInitialized()
 
         // Update timer's stored current milliseconds
-        timerStatus.setTimerMilliseconds(milliseconds.value ?: 0, prefsKey, true)
+        milliseconds.value?.let {
+                currentMillis -> timerStatus.setTimerMilliseconds(currentMillis, prefsKey, true)
+        } ?: Log.e(javaClass.name, "Error saving current milliseconds to preferences - milliseconds value is null")
 
         //  Cancel timer if it has been initialized
         if (::countdownTimer.isInitialized) countdownTimer.cancel()
@@ -102,6 +105,20 @@ class LifecycleAwareTimer internal constructor(
 
         // Cancel restart the CountDownTimer
         cancelAndRestartTimer()
+    }
+
+    /**
+     * Manual call to save the timer's current milliseconds
+     * (in any case your lifecycle owner's onPause would not be called before you'd like to access
+     * the timer elsewhere).
+     * */
+    fun saveCurrentTime() {
+        checkInitialized()
+
+        // Update timer's stored current milliseconds
+        milliseconds.value?.let {
+                currentMillis -> timerStatus.setTimerMilliseconds(currentMillis, prefsKey, true)
+        } ?: Log.e(javaClass.name, "Error saving current milliseconds to preferences - milliseconds value is null")
     }
     // endregion
 

--- a/sample/src/main/java/com/franieldancis/lifecycleawaretimer/example/MainActivity.kt
+++ b/sample/src/main/java/com/franieldancis/lifecycleawaretimer/example/MainActivity.kt
@@ -74,7 +74,6 @@ class MainActivity : AppCompatActivity() {
                 timerSeconds2.text = String.format(ZERO_PAD_FORMAT_PATTERN, seconds % 60)
             })
         }
-
     }
 
     @Suppress("UNUSED_PARAMETER")


### PR DESCRIPTION
- Edgecase where lifecycle owner's onPause would not be called, e.g. launching a DialogFragment).